### PR TITLE
fix(ReactNativeNFCModule): crash when app returns from BG

### DIFF
--- a/android/src/main/java/com/novadart/reactnativenfc/ReactNativeNFCModule.java
+++ b/android/src/main/java/com/novadart/reactnativenfc/ReactNativeNFCModule.java
@@ -73,7 +73,10 @@ public class ReactNativeNFCModule extends ReactContextBaseJavaModule
 
     @Override
     public void onNewIntent(Intent intent) {
-        handleIntent(intent, false);
+        Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
+        if (tag != null) {
+            handleIntent(intent, false);
+        }
     }
     
     @Override

--- a/android/src/main/java/com/novadart/reactnativenfc/ReactNativeNFCModule.java
+++ b/android/src/main/java/com/novadart/reactnativenfc/ReactNativeNFCModule.java
@@ -73,7 +73,10 @@ public class ReactNativeNFCModule extends ReactContextBaseJavaModule
 
     @Override
     public void onNewIntent(Intent intent) {
+      Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
+      if (tag != null) {
         handleIntent(intent, false);
+      }
     }
     
     @Override


### PR DESCRIPTION
**Crash log:**

java.lang.NullPointerException: Attempt to invoke virtual method 'byte[] android.nfc.Tag.getId()' on a null object reference
    at com.novadart.reactnativenfc.ReactNativeNFCModule.getSerialNumber(ReactNativeNFCModule.java:253)
    at com.novadart.reactnativenfc.ReactNativeNFCModule.handleIntent(ReactNativeNFCModule.java:150)
    at com.novadart.reactnativenfc.ReactNativeNFCModule.onNewIntent(ReactNativeNFCModule.java:76)
    at com.facebook.react.bridge.ReactContext.onNewIntent(ReactContext.java:197)
    at com.facebook.react.ReactInstanceManager.onNewIntent(ReactInstanceManager.java:469)
    at com.facebook.react.ReactActivityDelegate.onNewIntent(ReactActivityDelegate.java:179)
    at com.facebook.react.ReactActivity.onNewIntent(ReactActivity.java:107)
    at android.app.Activity.performNewIntent(Activity.java:7086)
    at android.app.Instrumentation.callActivityOnNewIntent(Instrumentation.java:1309)
    at android.app.Instrumentation.callActivityOnNewIntent(Instrumentation.java:1321)
    at android.app.ActivityThread.deliverNewIntents(ActivityThread.java:2995)
    at android.app.ActivityThread.performNewIntents(ActivityThread.java:3011)
    at android.app.ActivityThread.handleNewIntent(ActivityThread.java:3027)
    at android.app.ActivityThread.-wrap14(Unknown Source:0)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1717)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:171)
    at android.app.ActivityThread.main(ActivityThread.java:6656)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:547)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:873)
